### PR TITLE
Fixed membership page link

### DIFF
--- a/src/pages/membership.md
+++ b/src/pages/membership.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   order: 4
 membershipHeader: Join the coalition
 membershipAnnouncement: "**We are now accepting applications for membership in the DSC from April 10th through May 7th, 2023. </br></br> Prior to filling out an application please review the 2023 DSC Membership Policy to ensure your company is eligible
-  and to see the cost of membership: [2023 DSC Membership Policy](/pdfs/Membership-Policy-2023.pdf)</br></br> Fill out your application here: [DSC 2023 Membership
+  and to see the cost of membership: [2023 DSC Membership Policy](/assets/pdf/Membership-Policy-2023.pdf)</br></br> Fill out your application here: [DSC 2023 Membership
   Application](https://www.surveymonkey.com/r/WQ5JRKR)**"
 ---
 ### Who can join


### PR DESCRIPTION
![image](https://github.com/DSCoalition/dsc-11ty-cms/assets/62570179/2570c08d-3ebf-46a3-b452-264ff745bde9)

Changed the link address for 2023 Membership Page to fix 404 error. Closes #62 